### PR TITLE
Fixes to bring code in line with current Elixir (v1.18) and packages (mongodb_driver, jason, plug_cowboy)

### DIFF
--- a/movie_api/config/config.exs
+++ b/movie_api/config/config.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 # Importing the configuration depending on the environment.
 # If Mix.env() == "dev", we'll have import_config "dev.exs"

--- a/movie_api/config/dev.exs
+++ b/movie_api/config/dev.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 # The server will run on this port.
 config :movie_api, port: 8000

--- a/movie_api/config/test.exs
+++ b/movie_api/config/test.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :movie_api, port: 5000
 

--- a/movie_api/lib/movie_api/application.ex
+++ b/movie_api/lib/movie_api/application.ex
@@ -4,8 +4,6 @@ defmodule MovieApi.Application do
   require Logger
 
   def start(_type, _args) do
-    import Supervisor.Spec
-
     children = [
       # Adding cowboy in the children processes.
       {Plug.Cowboy, scheme: :http, plug: Endpoints, options: [port: port()]},
@@ -13,7 +11,7 @@ defmodule MovieApi.Application do
       # We connect to MongoDB and give the name database
       # The process will be accessible inside the project with the name database
       # instead of its pid.
-      worker(Mongo, [[name: :database, database: database(), pool_size: 2]])
+      %{id: Mongo, start: {Mongo, :start_link, [[name: :database, database: database()]]}}
     ]
 
     opts = [strategy: :one_for_one, name: MovieApi.Supervisor]

--- a/movie_api/lib/services/movie_service.ex
+++ b/movie_api/lib/services/movie_service.ex
@@ -1,21 +1,30 @@
 defmodule Services.MovieService do
+  require Logger
 
   alias Repository.MovieRepository
 
   # Getting all the movies.
   def get_all_movies() do
-    movies = MovieRepository.list()
-    # We transform the movies to a list.
-    movies = movies
-             |> Enum.map(fn (%{"_id" => id} = m) ->
-                              # Transforming the BSON ObjectId to string (binary)
-                              id = BSON.ObjectId.encode!(id)
+    cursor = MovieRepository.list()
+    result = case cursor do
+      {:error, error} ->
+        Logger.info("Error: #{inspect error}")
+        {:error, error}
 
-                              # Encoding the map to json.
-                              Jason.encode!(%{ m | "_id" => id })
-                         end)
+      _ ->
+        # We transform the movies to a list.
+        movies = cursor
+                 |> Enum.map(fn (%{"_id" => id} = m) ->
+                                  # Transforming the BSON ObjectId to string (binary)
+                                  id = BSON.ObjectId.encode!(id)
 
-    {:ok, movies}
+                                  # Encoding the map to json.
+                                  Jason.encode!(%{ m | "_id" => id })
+                             end)
+        
+        {:ok, movies}
+    end
+    result
   end
 
   # Getting a movie by it's ID.

--- a/movie_api/mix.exs
+++ b/movie_api/mix.exs
@@ -14,7 +14,7 @@ defmodule MovieApi.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger, :mongodb, :poolboy],
+      extra_applications: [:logger, :mongodb_driver, :poolboy],
       mod: {MovieApi.Application, []}
     ]
   end
@@ -22,10 +22,10 @@ defmodule MovieApi.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:mongodb, "~> 0.5.1"},
+      {:mongodb_driver, "~> 1.5.2"},
       {:poolboy, "~> 1.5.2"},
-      {:plug_cowboy, "~> 2.2.1"},
-      {:jason, "~> 1.2.0"}
+      {:plug_cowboy, "~> 2.7.3"},
+      {:jason, "~> 1.4.4"}
     ]
   end
 end

--- a/movie_api/test/endpoint_test.exs
+++ b/movie_api/test/endpoint_test.exs
@@ -1,6 +1,6 @@
 defmodule EndpointTest do
   use ExUnit.Case
-  use Plug.Test
+  import Plug.Test
 
   alias Endpoints
 


### PR DESCRIPTION
I was using your code to learn Elixir.   I know your code is 5 year old now, so I used it to gain some experience by fixing it up to be current.

Here's what I have done in this PR:

1. Upgraded mongodb to mongodb_driver.  
2. Upgraded plug_cowboy and jason to current versions.
3. Added a catch to catch the error from mongo on /all (for debugging)
4. Corrected a few issues for Elixir v1.18, including:
    a. "use" now throws a warning, so I have changed to"import" 
    b. Mix.Config is now Config
    c. Child specification structures have changed.

Thanks for a good example to work with!